### PR TITLE
Add Node.js Muki module

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Node"]
+	path = Node
+	url = https://github.com/sprusr/muki.js.git


### PR DESCRIPTION
I've created a JavaScript version of the Muki API and added it as a submodule to this repo in this PR. This opens up the Muki to many more developers (myself included) who don't know how/don't want to develop for Android or iOS.

Big help from @akx with figuring out the image format.